### PR TITLE
Added a Nix Flake for easier compilation using Nix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ render.ppm
 
 # Windows File System
 desktop.ini
+
+# Nix result
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1637316267,
+        "narHash": "sha256-hfAA/0W3tycKKOSwP7Xt6FXLG9h/FgCu45wdGubHtV0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "24528474d2b3370f2f23879a557ae2cc92a5d50b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       };
       path-tracing-renderer = (with pkgs; stdenv.mkDerivation {
           pname = "path-tracing-renderer";
-          version = "1.0.0";
+          version = "0.0.1";
           src = ./.;
           nativeBuildInputs = [
             gcc

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+
+{
+  description = "A flake for building Path-Tracing_Renderer";
+  inputs = {
+    nixpkgs = {
+      url = "nixpkgs/nixos-21.05";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+      path-tracing-renderer = (with pkgs; stdenv.mkDerivation {
+          pname = "path-tracing-renderer";
+          version = "1.0.0";
+          src = ./.;
+          nativeBuildInputs = [
+            gcc
+            glm
+          ];
+          buildPhase = "g++ -march=native -O2 -s -std=c++11 -Wall -Wextra -Wshadow \"./src/image.cpp\" \"./src/rng.cpp\" \"./src/main.cpp\" -o \"./OpenPT\"";
+          installPhase = ''
+            mkdir -p $out/bin
+            mv OpenPT $out/bin
+          '';
+        }
+      );
+    in rec {
+      defaultApp = flake-utils.lib.mkApp {
+        drv = defaultPackage;
+      };
+      defaultPackage = path-tracing-renderer;
+      devShell = pkgs.mkShell {
+        buildInputs = [
+          path-tracing-renderer
+        ];
+      };
+    }      
+  );
+}


### PR DESCRIPTION
This should make it easier for people using Nix to compile the project. By running `nix build .#` It'll fetch the required dependencies and build the binary at the same time.

This should theoretically work on macOS too but is **not** tested.